### PR TITLE
adds ability to get using a 'where' param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export declare class MikroOrmService extends AdapterService<any> {
     private name;
     constructor(options: MikroOrmServiceOptions);
     setup(app: any): void;
-    get(id: Id): Promise<AnyEntity<any>>;
+    get(id: Id, params: Params): Promise<AnyEntity<any>>;
     find(params?: Params): Promise<AnyEntity<any>[]>;
     create(data: Partial<AnyEntity<any>>): Promise<AnyEntity<any>>;
     patch(id: Id, data: Partial<AnyEntity<any>>): Promise<AnyEntity<any>>;

--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ class MikroOrmService extends adapter_commons_1.AdapterService {
     setup(app) {
         this.app = app;
     }
-    async get(id) {
-        const entity = await this.repository.findOne(id);
+    async get(id, params) {
+        const where = params.where || (params.query && params.query.where);
+        const entity = await this.repository.findOne(id || where);
         if (!entity) {
             throw new errors_1.NotFound(`${this.name} not found`);
         }

--- a/index.ts
+++ b/index.ts
@@ -30,8 +30,9 @@ export class MikroOrmService extends AdapterService<any> {
     this.app = app;
   }
 
-  async get(id: Id): Promise<AnyEntity<any>> {
-    const entity = await this.repository.findOne(id);
+  async get(id: Id, params: Params): Promise<AnyEntity<any>> {
+    const where = params.where || (params.query && params.query.where);
+    const entity = await this.repository.findOne(id || where);
 
     if (!entity) {
       throw new NotFound(`${this.name} not found`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-mikro-orm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A service adapter for MikroORM",
   "main": "build/index.js",
   "author": "jacobleesinger",


### PR DESCRIPTION
Old behavior:
-------------
- `get` must be called with an id

New behavior:
--------------
- `get` can be called with a null id
- if no `id`, `get` will attempt find by `params.where` or `params.query.where`
- ex: getting a user by email instead of id:
```typescript
const user = await userService.get(null, { where: { email: 'test@test.com' } });
```