### PR TITLE
adds optional params argument to all service methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,9 +15,9 @@ export declare class MikroOrmService extends AdapterService<any> {
     setup(app: any): void;
     get(id: NullableId, params?: Params): Promise<AnyEntity<any>>;
     find(params?: Params): Promise<AnyEntity<any>[]>;
-    create(data: Partial<AnyEntity<any>>): Promise<AnyEntity<any>>;
-    patch(id: Id, data: Partial<AnyEntity<any>>): Promise<AnyEntity<any>>;
-    remove(id: Id): Promise<AnyEntity<any>>;
+    create(data: Partial<AnyEntity<any>>, params?: Params): Promise<AnyEntity<any>>;
+    patch(id: Id, data: Partial<AnyEntity<any>>, params?: Params): Promise<AnyEntity<any>>;
+    remove(id: Id, params?: Params): Promise<AnyEntity<any>>;
 }
 export default function (options: MikroOrmServiceOptions): MikroOrmService;
 export {};

--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@ class MikroOrmService extends adapter_commons_1.AdapterService {
         const entities = await this.repository.find(params.where, params.options);
         return entities;
     }
-    async create(data) {
+    async create(data, params) {
         const entity = new this.Entity(data);
         await this.repository.persistAndFlush(entity);
         return entity;
     }
-    async patch(id, data) {
+    async patch(id, data, params) {
         const entity = await this.repository.findOne(id);
         if (!entity) {
             throw new errors_1.NotFound(`cannot patch ${this.name}, entity not found`);
@@ -41,7 +41,7 @@ class MikroOrmService extends adapter_commons_1.AdapterService {
         await this.repository.persistAndFlush(entity);
         return entity;
     }
-    async remove(id) {
+    async remove(id, params) {
         const entity = await this.repository.findOne(id);
         if (!entity) {
             throw new errors_1.NotFound(`cannot remove ${this.name}, entity not found`);

--- a/index.ts
+++ b/index.ts
@@ -49,13 +49,13 @@ export class MikroOrmService extends AdapterService<any> {
     return entities;
   }
 
-  async create(data: Partial<AnyEntity<any>>): Promise<AnyEntity<any>> {
+  async create(data: Partial<AnyEntity<any>>, params?: Params): Promise<AnyEntity<any>> {
     const entity = new this.Entity(data);
     await this.repository.persistAndFlush(entity);
     return entity;
   }
 
-  async patch(id: Id, data: Partial<AnyEntity<any>>): Promise<AnyEntity<any>> {
+  async patch(id: Id, data: Partial<AnyEntity<any>>, params?: Params): Promise<AnyEntity<any>> {
     const entity = await this.repository.findOne(id);
 
     if (!entity) {
@@ -67,7 +67,7 @@ export class MikroOrmService extends AdapterService<any> {
     return entity;
   }
 
-  async remove(id: Id): Promise<AnyEntity<any>> {
+  async remove(id: Id, params?: Params): Promise<AnyEntity<any>> {
     const entity = await this.repository.findOne(id);
 
     if (!entity) {


### PR DESCRIPTION
old behavior: some service methods (`create`, `patch`, and `remove`) do not support passing params
new behavior: all service methods accept the optional params argument