### PR TITLE
update service to be generic + add correct input/output types for methods

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,11 +1,11 @@
 import { AdapterService, ServiceOptions } from '@feathersjs/adapter-commons';
 import { NullableId, Params } from '@feathersjs/feathers';
 import { EntityRepository, MikroORM } from '@mikro-orm/core';
-interface MikroOrmServiceOptions<T> extends Partial<ServiceOptions> {
+interface MikroOrmServiceOptions<T = any> extends Partial<ServiceOptions> {
     Entity: T;
     orm: MikroORM;
 }
-export declare class Service<T> extends AdapterService {
+export declare class Service<T = any> extends AdapterService {
     protected orm: MikroORM;
     protected Entity: T;
     protected repository: EntityRepository<T>;
@@ -17,5 +17,5 @@ export declare class Service<T> extends AdapterService {
     patch(id: NullableId, data: Partial<T>, params?: Params): Promise<T>;
     remove(id: NullableId, params?: Params): Promise<T>;
 }
-export default function <T>(options: MikroOrmServiceOptions<T>): Service<T>;
+export default function <T = any>(options: MikroOrmServiceOptions<T>): Service<T>;
 export {};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,22 +1,21 @@
 import { AdapterService, ServiceOptions } from '@feathersjs/adapter-commons';
 import { NullableId, Params } from '@feathersjs/feathers';
-import { AnyEntity, EntityRepository, MikroORM } from '@mikro-orm/core';
-interface MikroOrmServiceOptions extends Partial<ServiceOptions> {
-    Entity: AnyEntity;
+import { EntityRepository, MikroORM } from '@mikro-orm/core';
+interface MikroOrmServiceOptions<T> extends Partial<ServiceOptions> {
+    Entity: T;
     orm: MikroORM;
-    name: string;
 }
-export declare class Service extends AdapterService {
+export declare class Service<T> extends AdapterService {
     protected orm: MikroORM;
-    protected Entity: any;
-    protected repository: EntityRepository<any>;
+    protected Entity: T;
+    protected repository: EntityRepository<T>;
     protected name: string;
-    constructor(options: MikroOrmServiceOptions);
-    get(id: NullableId, params?: Params): Promise<any>;
-    find(params?: Params): Promise<any[]>;
-    create(data: Partial<AnyEntity>, params?: Params): Promise<any>;
-    patch(id: NullableId, data: Partial<AnyEntity>, params?: Params): Promise<any>;
-    remove(id: NullableId, params?: Params): Promise<any>;
+    constructor(options: MikroOrmServiceOptions<T>);
+    get(id: NullableId, params?: Params): Promise<T>;
+    find(params?: Params): Promise<T[]>;
+    create(data: Partial<T>, params?: Params): Promise<T>;
+    patch(id: NullableId, data: Partial<T>, params?: Params): Promise<T>;
+    remove(id: NullableId, params?: Params): Promise<T>;
 }
-export default function (options: MikroOrmServiceOptions): Service;
+export default function <T>(options: MikroOrmServiceOptions<T>): Service<T>;
 export {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,11 +6,13 @@ const core_1 = require("@mikro-orm/core");
 const errors_1 = require("@feathersjs/errors");
 class Service extends adapter_commons_1.AdapterService {
     constructor(options) {
+        const { orm, Entity } = options;
         super(options);
-        this.Entity = options.Entity;
-        this.orm = options.orm;
-        this.repository = this.orm.em.getRepository(options.name);
-        this.name = options.name;
+        this.Entity = Entity;
+        this.orm = orm;
+        const name = core_1.Utils.className(Entity);
+        this.repository = this.orm.em.getRepository(name);
+        this.name = name;
     }
     async get(id, params) {
         var _a;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@ import { NullableId, Params } from '@feathersjs/feathers';
 import { EntityRepository, MikroORM, wrap, Utils } from '@mikro-orm/core';
 import { NotFound } from '@feathersjs/errors';
 
-interface MikroOrmServiceOptions<T> extends Partial<ServiceOptions> {
+interface MikroOrmServiceOptions<T = any> extends Partial<ServiceOptions> {
   Entity: T;
   orm: MikroORM;
 }
 
-export class Service<T> extends AdapterService {
+export class Service<T = any> extends AdapterService {
   protected orm: MikroORM;
   protected Entity: T;
   protected repository: EntityRepository<T>;
@@ -87,6 +87,6 @@ export class Service<T> extends AdapterService {
   }
 }
 
-export default function<T> (options: MikroOrmServiceOptions<T>): Service<T> {
+export default function<T = any> (options: MikroOrmServiceOptions<T>): Service<T> {
   return new Service(options);
 }

--- a/test/app.ts
+++ b/test/app.ts
@@ -5,7 +5,6 @@ import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 import createService from '../src/';
 import { Book } from './entities/Book';
 import { BaseEntity } from './entities/BaseEntity';
-import { EntityClass } from '@mikro-orm/core/typings';
 
 export async function setupApp (): Promise<Application> {
   const app = feathers();
@@ -31,7 +30,6 @@ export async function setupApp (): Promise<Application> {
 
   const bookService = createService({
     Entity: Book,
-    name: 'Book',
     orm
   });
 


### PR DESCRIPTION
## Summary of Changes
- updates the exported `Service` to be a generic which takes the type of the entity as a typearg (default `any`)
- this should give us more accurate argument and return types for service methods, i.e. the `create` method of a service for a `User` entity will now require an argument of type `Partial<User>` and have its return value typed as `Promise<User>`