### PR TITLE
[remove] prefer removing by id over params, use findOneOrFail to get entity

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,8 +57,13 @@ class Service extends adapter_commons_1.AdapterService {
     async remove(id, params) {
         if (id) {
             // removing a single entity by id
-            const where = (params === null || params === void 0 ? void 0 : params.where) || id;
-            const entity = await this.get(where);
+            let entity;
+            try {
+                entity = await this.repository.findOneOrFail(id);
+            }
+            catch (e) {
+                throw new errors_1.NotFound(`${this.name} not found.`);
+            }
             await this.repository.removeAndFlush(entity);
             return entity;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,9 @@ class Service extends adapter_commons_1.AdapterService {
             // removing a single entity by id
             let entity;
             try {
+                // repository methods often complain about argument types being incorrect even when they're not
+                // `string` and `number` types _should_ be assignable to `FilterQuery`, but they aren't.
+                // comment by package author/maintainer: https://github.com/mikro-orm/mikro-orm/issues/1405#issuecomment-775841265
                 entity = await this.repository.findOneOrFail(id);
             }
             catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,9 @@ export class Service<T = any> extends AdapterService {
       let entity: T;
 
       try {
+        // repository methods often complain about argument types being incorrect even when they're not
+        // `string` and `number` types _should_ be assignable to `FilterQuery`, but they aren't.
+        // comment by package author/maintainer: https://github.com/mikro-orm/mikro-orm/issues/1405#issuecomment-775841265
         entity = await this.repository.findOneOrFail(id as FilterQuery<T>);
       } catch (e) {
         throw new NotFound(`${this.name} not found.`);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -102,6 +102,21 @@ describe('feathers-mikro-orm', () => {
         }
       });
 
+      it('ignores params when deleting by id', async () => {
+        const options = { title: 'test' };
+        const params = { query: {} };
+        const savedBook = await service.create(options);
+
+        await service.remove(savedBook.uuid, params);
+
+        try {
+          await service.get(savedBook.uuid);
+          fail();
+        } catch (e) {
+          expect(e).toEqual(new NotFound('Book not found.'));
+        }
+      });
+
       it('returns the deleted book', async () => {
         const options = { title: 'test' };
         const initial = await service.create(options);


### PR DESCRIPTION
[ticket](https://trello.com/c/p8UcrBmd/1315-error-on-individually-scheduled-deletions)

## Summary
Fixes issues that were causing some removals to fail

## Changes
- prefers using `id` over `params` if it is provided
- directly uses `repository.findOneOrFail` to get an individual entity for deletion instead of calling the service's `get` method
 - `removeAndFlush` requires the first argument to be a mikro-orm entity. `get` may or may not return an entity, as hooks are called even when calling it internally and may change its return value.

## Testing
- added regression test case
- tested locally by linking package in saas