### PR TITLE
add pagination for find method

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "@feathersjs/errors": "^4.5.10",
     "@feathersjs/feathers": "^4.5.10",
     "@mikro-orm/core": "^4.4.2",
+    "lodash": "^4.17.21",
     "uuid": "^8.3.0"
   },
   "devDependencies": {
     "@mikro-orm/postgresql": "^4.4.2",
     "@mikro-orm/reflection": "^4.4.2",
     "@types/jest": "^26.0.8",
+    "@types/lodash": "^4.14.173",
     "@types/uuid": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,6 +671,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.173":
+  version "4.14.173"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.173.tgz#9d3b674c67a26cf673756f6aca7b429f237f91ed"
+  integrity sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg==
+
 "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -3339,7 +3344,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.x, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.x, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
[ticket](https://trello.com/c/B7mq9TSB/1946-add-pagination-capabilities-to-mikroorm)

## Summary
Adds pagination capabilities for find method

Pagination works as described in the [Feathers database adapter docs](https://docs.feathersjs.com/api/databases/adapters.html)
[pagination](https://docs.feathersjs.com/api/databases/common.html#pagination)
[$limit query param](https://docs.feathersjs.com/api/databases/querying.html#limit)
[$skip query param](https://docs.feathersjs.com/api/databases/querying.html#skip)