### PR TITLE
allow options from query params or params.options

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -33,6 +33,12 @@ export declare class Service<T = any> extends AdapterService {
      * @returns Promise<Paginated<T>> a feathers Paginated object with the query results
      */
     private _findPaginated;
+    /**
+     * helper to translate feathers query syntax to mikro-orm options syntax
+     * @param query feathers query
+     * @returns FindOptions mikro-orm FindOptions
+     */
+    private _translateFeathersQueryToFindOptions;
 }
 export default function <T = any>(options: MikroOrmServiceOptions<T>): Service<T>;
 export {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ class Service extends adapter_commons_1.AdapterService {
         return entity;
     }
     async find(params) {
-        var _a, _b, _c, _d, _e;
+        var _a, _b, _c, _d;
         if (!params) {
             return this.repository.findAll(params);
         }
@@ -67,12 +67,16 @@ class Service extends adapter_commons_1.AdapterService {
         else if (((_b = params.query) === null || _b === void 0 ? void 0 : _b.$limit) || ((_c = params.query) === null || _c === void 0 ? void 0 : _c.$limit) === 0) {
             limit = (_d = params.query) === null || _d === void 0 ? void 0 : _d.$limit;
         }
-        const offset = ((_e = params.query) === null || _e === void 0 ? void 0 : _e.$skip) || 0;
-        const options = { limit, offset };
+        const queryOptions = this._translateFeathersQueryToFindOptions(lodash_1.pick(params.query, feathersSpecialQueryParameters));
+        const options = {
+            ...queryOptions,
+            ...params.options,
+            limit
+        };
         // if limit is 0, only run a counting query
         // and return a Paginated object with the count and an empty data array
         if (limit === 0) {
-            return await this._findCount(query, offset);
+            return await this._findCount(query, options.offset);
         }
         // if limit is set, run a findAndCount query and return a Paginated object
         if (limit) {
@@ -149,6 +153,19 @@ class Service extends adapter_commons_1.AdapterService {
             limit: options.limit,
             skip: options.offset || 0,
             data
+        };
+    }
+    /**
+     * helper to translate feathers query syntax to mikro-orm options syntax
+     * @param query feathers query
+     * @returns FindOptions mikro-orm FindOptions
+     */
+    _translateFeathersQueryToFindOptions(query) {
+        return {
+            ...lodash_1.omit(query, '$sort', '$skip', '$select', '$limit'),
+            orderBy: query.$sort,
+            offset: query.$skip,
+            fields: query.$select
         };
     }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -79,6 +79,34 @@ describe('feathers-mikro-orm', () => {
         expect(saved).not.toContainEqual(book2);
       });
 
+      it('honors feathers options passed as query params', async () => {
+        const options = { title: 'test' };
+        const options2 = { title: 'another' };
+        const book1 = await service.create(options);
+        const book2 = await service.create(options2);
+        // sort/order results using feathers $sort query param
+        const saved = await service.find({ query: { $sort: { title: 1 } } }) as Book[];
+        console.log('saved', saved);
+
+        expect(saved.length).toEqual(2);
+        expect(saved[0]).toEqual(book2);
+        expect(saved[1]).toEqual(book1);
+      });
+
+      it('honors mikro-orm options passed as params.options', async () => {
+        const options = { title: 'test' };
+        const options2 = { title: 'another' };
+        const book1 = await service.create(options);
+        const book2 = await service.create(options2);
+        // sort/order results using mikro-orm orderBy option in params
+        const saved = await service.find({ options: { orderBy: { title: 'ASC' } } }) as Book[];
+        console.log('saved', saved);
+
+        expect(saved.length).toEqual(2);
+        expect(saved[0]).toEqual(book2);
+        expect(saved[1]).toEqual(book1);
+      });
+
       describe('pagination', () => {
         it('returns a Paginated object if $limit query param is set', async () => {
           const options = { title: 'test' };


### PR DESCRIPTION
[ticket](https://trello.com/c/B7mq9TSB/1946-add-pagination-capabilities-to-mikroorm)

## Summary
Allows options to be passed to `find` either through feathers query param syntax or mikroORM `FindOptions` object passed as `params.options`